### PR TITLE
Increase memory settings for 64bit architecture, but leave the 32bit arc...

### DIFF
--- a/org.scala-ide.product/templates/scalaide.product
+++ b/org.scala-ide.product/templates/scalaide.product
@@ -21,12 +21,11 @@
    </configIni>
 
    <launcherArgs>
-      <vmArgs>-Xmx1048m
--Xms100m
--XX:MaxPermSize=256m</vmArgs>
-      <vmArgsMac>
--XstartOnFirstThread
--Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
+      <vmArgs>
+         <argsX86>-Xmx1048m -Xms100m -XX:MaxPermSize=256m</argsX86>
+         <argsX86_64>-Xmx2G -Xms200m -XX:MaxPermSize=384m</argsX86_64>
+      </vmArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
    </launcherArgs>
 
    <launcher>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
 
     <!-- plugin versions -->
-    <tycho.plugin.version>0.20.0</tycho.plugin.version>
+    <tycho.plugin.version>0.21.0</tycho.plugin.version>
 
 
     <build.id>${version.tag}-${maven.build.timestamp}-Typesafe</build.id>


### PR DESCRIPTION
...h the same.

Support for this setting arrived in Tycho 0.21.0, so bumping Tycho version as well.
