### PR TITLE
Set the application name to `Scala IDE`

### DIFF
--- a/org.scala-ide.sdk/plugin.xml
+++ b/org.scala-ide.sdk/plugin.xml
@@ -10,6 +10,7 @@
           name="Scala IDE">
        <property name="aboutImage" value="product.png"/>
        <property name="aboutText" value="%productBlurb"/>
+       <property name="appName" value="Scala IDE"/>
        <property
              name="preferenceCustomization"
              value="plugin_customization.ini">


### PR DESCRIPTION
This makes the Mac OS menu show `Scala IDE` instead of `eclipse`.
